### PR TITLE
Add Code of Conduct

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,9 @@
+# VanJS Code of Conduct
+
+VanJS is dedicated to providing a safe and comfortable environment for everyone, regardless of race, gender, sexual orientation, disability, physical appearance, body size, religion, or age. We do not tolerate harassment of participants in any form – this includes jokes made about the aforementioned qualities of personhood, even when made ironically.
+
+If someone asks you to stop behaviour that is perceived as inappropriate, leave them alone, or to end a conversation, do just that. The conversation is now over.
+
+Harassment includes deliberate intimidation, stalking or following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Sexual language and imagery is not appropriate for any VanJS presentation or sponsorship material. 
+
+Participants, speakers, volunteers, or sponsors violating these rules may be warned, sanctioned, expelled, or banned from the event at the discretion of [the organizers](https://www.meetup.com/vancouver-javascript-developers/members/?op=leaders). If you have a problem that requires mediation, find one of them, they are happy to help.


### PR DESCRIPTION
Fixes #4.

This is an expansion and refinement of the current VanJS Code of Conduct written by @afabbro. I have a lot of respect for her take on conduct and governance, so I kept the original code's "So short you will actually read it" approach, put pulled in a couple specific violations out of the SeattleJS code of conduct that seemed important to make explicit.

Keeping a Code of Conduct short has a tradeoff: there are various things that are not explicit in this proposed code that I've seen in other good (but long) code of conduct documents. Making a Code of Conduct long in an attempt to be exhaustive of all behaviours that constitute a violation has pros and cons, the main con being that fewer people will read and absorb a code of conduct that is long and feels like boilerplate.

If folks are not comfortable with the conciseness of this proposed code of conduct, I would propose adapting the [XOXO Code of Conduct](https://2018.xoxofest.com/conduct), which has a long list of inappropriate  behaviours, but formats it as a bulleted list which I think is helpful for getting people to actually absorb the information.